### PR TITLE
chore: fix quotation marks

### DIFF
--- a/docs/knowledge-base/fluent-overview.md
+++ b/docs/knowledge-base/fluent-overview.md
@@ -14,7 +14,7 @@ Fluent’s unique value proposition lies in its ability to:
 * and written in various programming languages (e.g., Solidity, Rust, and more),&#x20;
 * on a shared state execution environment.
 
-Fluent supports atomic composability between apps targeting different VMs, and “blended” apps composed of smart contracts mixed and matched between them. Interaction between the different types of contracts the network supports happens under the hood and is both atomic and happens in real-time.&#x20;
+Fluent supports atomic composability between apps targeting different VMs, and "blended" apps composed of smart contracts mixed and matched between them. Interaction between the different types of contracts the network supports happens under the hood and is both atomic and happens in real-time.&#x20;
 
 <table data-column-title-hidden data-view="cards">
     <tbody>

--- a/docs/knowledge-base/the-fluent-l2-network.md
+++ b/docs/knowledge-base/the-fluent-l2-network.md
@@ -7,7 +7,7 @@ sidebar_position: 3
 
 The Fluent L2 is a zk-rollup to run Wasm, EVM and SVM apps in one place. It supports blended execution of different VM targets on a shared state execution environment for real-time composability between apps from different ecosystems. The network is both EVM and SVM-compatible, maintaining ABI encodings for all contracts, and introducing no additional overhead for deploying apps in Solidity, Vyper, or Solana Rust.
 
-Ultimately, all VMs on Fluent are simulated at the execution layer and compile down to the Fluent rWasm VM for execution. Each VM is represented by a core Wasm-based system contract (the VM’s “compatibility contract”) which defines its EE standards and provides an API to access these functions. While Fluent will initially support Wasm, EVM, and SVM-based contracts, its design is extensible, enabling support for additional VM integrations.
+Ultimately, all VMs on Fluent are simulated at the execution layer and compile down to the Fluent rWasm VM for execution. Each VM is represented by a core Wasm-based system contract (the VM’s "compatibility contract") which defines its EE standards and provides an API to access these functions. While Fluent will initially support Wasm, EVM, and SVM-based contracts, its design is extensible, enabling support for additional VM integrations.
 
 ## App Deployment Models
 

--- a/docs/resources/glossary.md
+++ b/docs/resources/glossary.md
@@ -13,7 +13,7 @@ This allows for atomically composable apps using distinct programming language(s
 
 ## The Fluent L2
 
-The Fluent L2 is an Ethereum-centric zk-rollup for Wasm, EVM, and SVM based apps. It supports real-time composability between apps targeting different VMs, and “blended” apps composed of smart contracts mixed and matched between them. Interaction between the different types of contracts on the L2 happens under the hood and is both atomic and happens in real-time.
+The Fluent L2 is an Ethereum-centric zk-rollup for Wasm, EVM, and SVM based apps. It supports real-time composability between apps targeting different VMs, and "blended" apps composed of smart contracts mixed and matched between them. Interaction between the different types of contracts on the L2 happens under the hood and is both atomic and happens in real-time.
 
 ## The Fluentbase Framework
 


### PR DESCRIPTION
Some editors may not accurately render unexpected characters,appearing as gibberish or causing formatting problems.