### PR TITLE
fix(config): Enforce dark theme for all CSS elements

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -181,7 +181,7 @@ module.exports = {
         defaultMode: "dark",
         // Turn light and dark mode theme button on (false) or off (true).
         disableSwitch: true,
-        respectPrefersColorScheme: true,
+        respectPrefersColorScheme: false,
       },
     }),
   plugins: [


### PR DESCRIPTION
The dark theme is used by default, and there is no way to switch to the light one. However, some elements still use the light theme, such as warning messages and `<code>` tags.

Enforcing dark theme in the config sets proper dark colors everywhere.

Examples w/ the default light theme in the browser set:

<details>
  <summary>https://docs.fluent.xyz/developer-preview/connect-to-fluent</summary>  
Before:

![изображение](https://github.com/user-attachments/assets/f261845d-f995-49ef-a8a6-1e84ef6f1478)

After:  ![изображение](https://github.com/user-attachments/assets/26cdfe1f-51a8-417f-bfbf-5e5b7bdc9052)

</details>

<details>
  <summary>https://docs.fluent.xyz/developer-preview/build-with-the-fluentbase-sdk</summary>  

Before:

![изображение](https://github.com/user-attachments/assets/4e8cfced-007b-42ae-bf91-3332b596b487)

After:  

![изображение](https://github.com/user-attachments/assets/fa276eb5-b693-4574-9ed9-be0151997a94)


</details>