### PR TITLE
fix: correct broken links in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,7 @@ When creating issues:
 
 - **Documentation**: Check existing docs first
 - **Issues**: Search existing issues before creating new ones
-- **Discussions**: Use [Discord](https://discord.com/invite/fluentxyz") for discussing, in the #developer-forum channel before opening an issue or PR if you're unsure
+- **Discussions**: Use [Discord](https://discord.com/invite/fluentxyz) for discussing, in the #developer-forum channel before opening an issue or PR if you're unsure
 - **Community**: Join our community channels for real-time help
 
 ## Recognition

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -10,7 +10,7 @@ We're excited that you want to contribute to Fluent documentation! Your contribu
 
 :::prerequisite[Ready to Get Started?]
 
-Check out our comprehensive [Contributing Guidelines](https://github.com/fluentblabs-xyz/docs-docusaurus/blob/main/CONTRIBUTING.md) for everything you need to know!
+Check out our comprehensive [Contributing Guidelines](https://github.com/fluentlabs-xyz/docs-docusaurus/blob/main/CONTRIBUTING.md) for everything you need to know!
 
 :::
 
@@ -40,7 +40,7 @@ And finally, for more advanced contributors:
 ## Need Help?
 
 - **Questions?** Join our [Discord community](https://discord.com/invite/fluentxyz) in the #developer-forum channel
-- **Guidelines?** Check out our [Contributing Guidelines](https://github.com/fluentblabs-xyz/docs-docusaurus/blob/main/CONTRIBUTING.md) for detailed instructions
+- **Guidelines?** Check out our [Contributing Guidelines](https://github.com/fluentlabs-xyz/docs-docusaurus/blob/main/CONTRIBUTING.md) for detailed instructions
 - **Issues?** Search existing issues or create a new one on GitHub
 
 ---

--- a/docs/gblend/troubleshooting.md
+++ b/docs/gblend/troubleshooting.md
@@ -84,4 +84,4 @@ sudo systemctl start docker
 
 ## Still encountering issues?
 
-If none of the above solves the issue you're facing, refer [Discord](https://discord.com/invite/fluentxyz") for discussing the issue and getting support from fellow community devs and DevRels, in the _#devs-forum_ channel.
+If none of the above solves the issue you're facing, refer [Discord](https://discord.com/invite/fluentxyz) for discussing the issue and getting support from fellow community devs and DevRels, in the _#devs-forum_ channel.


### PR DESCRIPTION
## Summary
- Remove trailing curly quote character from Discord invite URLs in `CONTRIBUTING.md` and `docs/gblend/troubleshooting.md`
- Fix GitHub organization typo: `fluentblabs-xyz` -> `fluentlabs-xyz` in `docs/contribute.md` (2 occurrences)

## Details
The Contributing Guidelines links were returning 404 due to a typo in the organization name (`fluentblabs-xyz` instead of `fluentlabs-xyz`).

The Discord links had a trailing curly quote character (`"`) that broke the URL.

## Test plan
- [x] Verified correct GitHub link works: https://github.com/fluentlabs-xyz/docs-docusaurus/blob/main/CONTRIBUTING.md
- [x] Verified correct Discord link works: https://discord.com/invite/fluentxyz